### PR TITLE
RSP-3125: Remove last updated value for new review bodies

### DIFF
--- a/src/Application/Rsp.IrasService.Application/DTOS/Requests/BaseDto.cs
+++ b/src/Application/Rsp.IrasService.Application/DTOS/Requests/BaseDto.cs
@@ -5,7 +5,7 @@ public class BaseDto
     public Guid Id { get; set; }
     public bool IsActive { get; set; } = true;
     public DateTime CreatedDate { get; set; }
-    public DateTime UpdatedDate { get; set; }
+    public DateTime? UpdatedDate { get; set; }
     public string CreatedBy { get; set; } = null!;
     public string? UpdatedBy { get; set; }
 }

--- a/src/Domain/Rsp.IrasService.Domain/Entities/ReviewBody.cs
+++ b/src/Domain/Rsp.IrasService.Domain/Entities/ReviewBody.cs
@@ -23,7 +23,7 @@ public class ReviewBody : IAuditable
     public bool IsActive { get; set; } = true;
 
     public DateTime CreatedDate { get; set; }
-    public DateTime UpdatedDate { get; set; }
+    public DateTime? UpdatedDate { get; set; }
     public string CreatedBy { get; set; } = null!;
     public string? UpdatedBy { get; set; }
 

--- a/src/Infrastructure/Rsp.IrasService.Infrastructure/Migrations/20250521102626_NullableReviewBodyLastUpdated.Designer.cs
+++ b/src/Infrastructure/Rsp.IrasService.Infrastructure/Migrations/20250521102626_NullableReviewBodyLastUpdated.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Rsp.IrasService.Infrastructure;
 
@@ -11,9 +12,11 @@ using Rsp.IrasService.Infrastructure;
 namespace Rsp.IrasService.Infrastructure.Migrations
 {
     [DbContext(typeof(IrasContext))]
-    partial class IrasContextModelSnapshot : ModelSnapshot
+    [Migration("20250521102626_NullableReviewBodyLastUpdated")]
+    partial class NullableReviewBodyLastUpdated
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Rsp.IrasService.Infrastructure/Migrations/20250521102626_NullableReviewBodyLastUpdated.cs
+++ b/src/Infrastructure/Rsp.IrasService.Infrastructure/Migrations/20250521102626_NullableReviewBodyLastUpdated.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Rsp.IrasService.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class NullableReviewBodyLastUpdated : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "ReviewBodies",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedDate",
+                table: "ReviewBodies",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Infrastructure/Rsp.IrasService.Infrastructure/Repositories/ReviewBodyRepository.cs
+++ b/src/Infrastructure/Rsp.IrasService.Infrastructure/Repositories/ReviewBodyRepository.cs
@@ -22,7 +22,6 @@ public class ReviewBodyRepository(IrasContext irasContext) : IReviewBodyReposito
     {
         reviewBody.Id = Guid.NewGuid();
         reviewBody.CreatedDate = DateTime.Now;
-        reviewBody.UpdatedDate = DateTime.Now;
 
         await irasContext.ReviewBodies.AddAsync(reviewBody);
         await irasContext.SaveChangesAsync();


### PR DESCRIPTION
## What was the purpose of this ticket?

Make LastUpdated nullable and null on creation of new review bodies

## Jira Ref

Replace the `###` with the Jira Ticket number below

[RSP-3125](https://nihr.atlassian.net/browse/RSP-3125)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [] Refactoring
- [x] Bug-fix
- [] DevOps
- [] Testing

## Solution

What work was completed to cover off the story?

- List out changes made to the repo

## Checklist

- [ ] Your code builds clean without any  warnings
- [ ] You have added unit tests
- [ ] All the added unit tests add value i.e. assert the right thing?
- [ ] You are using the correct naming conventions
- [ ] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [ ] There are no dead code and no "TODO" comments left
- [ ] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.