### PR TITLE
RSP-4540 Manage review bodies - Status sorting in wrong direction

### DIFF
--- a/src/Application/Rsp.IrasService.Application/Specifications/GetReviewBodiesSpecification.cs
+++ b/src/Application/Rsp.IrasService.Application/Specifications/GetReviewBodiesSpecification.cs
@@ -49,8 +49,13 @@ public class GetReviewBodiesSpecification : Specification<RegulatoryBody>
             ("regulatorybodyname", "desc") => builder.OrderByDescending(x => x.RegulatoryBodyName).ThenBy(x => x.IsActive),
             ("countries", "asc") => builder.OrderBy(x => x.Countries.FirstOrDefault()).ThenBy(x => x.IsActive),
             ("countries", "desc") => builder.OrderByDescending(x => x.Countries.FirstOrDefault()).ThenBy(x => x.IsActive),
-            ("isactive", "asc") => builder.OrderBy(x => x.IsActive),
-            ("isactive", "desc") => builder.OrderByDescending(x => x.IsActive),
+
+            // Sort so that active records (IsActive == true) appear first when sorting ascending
+            ("isactive", "asc") => builder.OrderByDescending(x => x.IsActive),
+
+            // Sort so that inactive records (IsActive == false) appear first when sorting descending
+            ("isactive", "desc") => builder.OrderBy(x => x.IsActive),
+
             _ => builder.OrderBy(x => x.RegulatoryBodyName).ThenByDescending(x => x.IsActive)
         };
 


### PR DESCRIPTION
## What was the purpose of this ticket?

Manage review bodies - Status sorting in wrong direction

## Jira Ref

Replace the `###` with the Jira Ticket number below

[RSP-4540](https://nihr.atlassian.net/browse/RSP-4540)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [] Refactoring
- [X] Bug-fix
- [] DevOps
- [] Testing

## Solution

What work was completed to cover off the story?

- Updated the specification class and added comments to explain changes

## Checklist

- [ ] Your code builds clean without any  warnings
- [ ] You have added unit tests
- [ ] All the added unit tests add value i.e. assert the right thing?
- [ ] You are using the correct naming conventions
- [ ] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [ ] There are no dead code and no "TODO" comments left
- [ ] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.