### PR TITLE
fix: Remove 'other' modification type

### DIFF
--- a/src/Infrastructure/Rsp.IrasService.Infrastructure/Repositories/ProjectRecordRepository.cs
+++ b/src/Infrastructure/Rsp.IrasService.Infrastructure/Repositories/ProjectRecordRepository.cs
@@ -199,8 +199,7 @@ public class ProjectRecordRepository(IrasContext irasContext) : IProjectRecordRe
                        .Where(a => a.ProjectRecordId == pr.Id && a.QuestionId == ProjectRecordConstants.SponsorOrganisation)
                        .Select(a => a.Response)
                        .FirstOrDefault() ?? string.Empty,
-                   CreatedAt = pm.CreatedDate,
-                   ModificationType = DetermineModificationType(pm)
+                   CreatedAt = pm.CreatedDate
                };
     }
 
@@ -227,6 +226,8 @@ public class ProjectRecordRepository(IrasContext irasContext) : IProjectRecordRe
                 {
                     mod.ParticipatingNation = string.Empty;
                 }
+
+                mod.ModificationType = DetermineModificationType();
 
                 return mod;
             })
@@ -266,26 +267,15 @@ public class ProjectRecordRepository(IrasContext irasContext) : IProjectRecordRe
             : modifications.OrderBy(keySelector);
     }
 
-    private static string DetermineModificationType(ProjectModification pm)
+    private static string DetermineModificationType()
     {
-        if (pm.ProjectModificationChanges.Any
-        (
-            c => c.AreaOfChange == ProjectRecordConstants.ParticipatingOrgs &&
-            c.SpecificAreaOfChange == ProjectRecordConstants.MajorModificationAreaOfChange
-        ))
+        var random = new Random();
+        var modificationType = random.Next(1, 3);
+        return modificationType switch
         {
-            return "Modification of an important detail";
-        }
-
-        if (pm.ProjectModificationChanges.Any
-        (
-            c => c.AreaOfChange == ProjectRecordConstants.ParticipatingOrgs &&
-            c.SpecificAreaOfChange == ProjectRecordConstants.MinorModificationAreaOfChange
-        ))
-        {
-            return "Minor modifications";
-        }
-
-        return "Other";
+            1 => "Modification of an important detail",
+            2 => "Minor modification",
+            _ => ""
+        };
     }
 }

--- a/tests/UnitTests/Rsp.IrasService.UnitTests/Services/ProjectModifiationServiceTests/GetModificationsTests.cs
+++ b/tests/UnitTests/Rsp.IrasService.UnitTests/Services/ProjectModifiationServiceTests/GetModificationsTests.cs
@@ -132,7 +132,6 @@ public class GetModificationsTests : TestServiceBase<object> // ✅ Use `object`
             ToDate = new DateTime(2024, 1, 2),
             LeadNation = new List<string> { "England" },
             ParticipatingNation = new List<string> { "Wales" },
-            ModificationTypes = new List<string> { "Modification of an important detail" }
         };
 
         // Act
@@ -144,6 +143,5 @@ public class GetModificationsTests : TestServiceBase<object> // ✅ Use `object`
         list[0].ChiefInvestigator.ShouldBe("Dr Smith");
         list[0].LeadNation.ShouldBe("England");
         list[0].ParticipatingNation.ShouldBe("Wales, Wales");
-        list[0].ModificationType.ShouldBe("Modification of an important detail");
     }
 }


### PR DESCRIPTION
## What was the purpose of this ticket?

Remove 'other' from modification type.

As the modification type logic is not yet implemented, we are randomly generating types to allow for user testing 🙈.

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [] Refactoring
- [x] Bug-fix
- [] DevOps
- [] Testing
