### PR TITLE
RSP-4305: Consider modification ID as a number when sorting

### DIFF
--- a/src/Domain/Rsp.IrasService.Domain/Entities/ProjectModificationResult.cs
+++ b/src/Domain/Rsp.IrasService.Domain/Entities/ProjectModificationResult.cs
@@ -4,6 +4,7 @@ public class ProjectModificationResult
 {
     public string ModificationId { get; set; } = null!;
     public string IrasId { get; set; } = null!;
+    public int ModificationNumber { get; set; }
     public string ShortProjectTitle { get; set; } = null!;
     public string ModificationType { get; set; } = null!;
     public string ChiefInvestigator { get; set; } = null!;


### PR DESCRIPTION
## What was the purpose of this ticket?

Consider modification Id as a number when sorting

## Jira Ref

[RSP-4305](https://nihr.atlassian.net/browse/RSP-4305)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [] Refactoring
- [x] Bug-fix
- [] DevOps
- [] Testing