### PR TITLE
RSP-5030 Approvals - Search - Incorrect does not show modifications that have been assigned to a study wide reviewer

### DIFF
--- a/src/Application/Rsp.IrasService.Application/DTOS/Requests/ModificationSearchRequest.cs
+++ b/src/Application/Rsp.IrasService.Application/DTOS/Requests/ModificationSearchRequest.cs
@@ -12,4 +12,5 @@ public class ModificationSearchRequest
     public List<string> ParticipatingNation { get; set; } = [];
     public List<string> ModificationTypes { get; set; } = [];
     public string? ReviewerId { get; set; } = null;
+    public bool IncludeReviewerId { get; set; }
 }

--- a/src/Infrastructure/Rsp.IrasService.Infrastructure/Repositories/ProjectModificationRepository.cs
+++ b/src/Infrastructure/Rsp.IrasService.Infrastructure/Repositories/ProjectModificationRepository.cs
@@ -165,9 +165,11 @@ public class ProjectModificationRepository(IrasContext irasContext) : IProjectMo
                 // Map ParticipatingNation codes to names
                 if (!string.IsNullOrWhiteSpace(mod.ParticipatingNation))
                 {
-                    var parts = mod.ParticipatingNation.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    var parts = mod.ParticipatingNation.Split(',',
+                        StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
                     var mapped = parts
-                        .Select(code => ProjectRecordConstants.NationIdMap.TryGetValue(code, out var name) ? name : null)
+                        .Select(code =>
+                            ProjectRecordConstants.NationIdMap.TryGetValue(code, out var name) ? name : null)
                         .Where(n => !string.IsNullOrEmpty(n));
                     mod.ParticipatingNation = string.Join(", ", mapped);
                 }
@@ -182,13 +184,15 @@ public class ProjectModificationRepository(IrasContext irasContext) : IProjectMo
             })
             .Where(x =>
                 (string.IsNullOrEmpty(searchQuery.IrasId)
-                    || x.IrasId.Contains(searchQuery.IrasId, StringComparison.OrdinalIgnoreCase))
+                 || x.IrasId.Contains(searchQuery.IrasId, StringComparison.OrdinalIgnoreCase))
                 && (string.IsNullOrEmpty(searchQuery.ChiefInvestigatorName)
-                    || x.ChiefInvestigator.Contains(searchQuery.ChiefInvestigatorName, StringComparison.OrdinalIgnoreCase))
+                    || x.ChiefInvestigator.Contains(searchQuery.ChiefInvestigatorName,
+                        StringComparison.OrdinalIgnoreCase))
                 && (string.IsNullOrEmpty(searchQuery.ShortProjectTitle)
                     || x.ShortProjectTitle.Contains(searchQuery.ShortProjectTitle, StringComparison.OrdinalIgnoreCase))
                 && (string.IsNullOrEmpty(searchQuery.SponsorOrganisation)
-                    || x.SponsorOrganisation.Contains(searchQuery.SponsorOrganisation, StringComparison.OrdinalIgnoreCase))
+                    || x.SponsorOrganisation.Contains(searchQuery.SponsorOrganisation,
+                        StringComparison.OrdinalIgnoreCase))
                 && (!searchQuery.FromDate.HasValue
                     || x.CreatedAt >= searchQuery.FromDate.Value)
                 && (!searchQuery.ToDate.HasValue
@@ -201,9 +205,8 @@ public class ProjectModificationRepository(IrasContext irasContext) : IProjectMo
                         .Any(pn => searchQuery.ParticipatingNation.Contains(pn, StringComparer.OrdinalIgnoreCase)))
                 && (searchQuery.ModificationTypes.Count == 0
                     || searchQuery.ModificationTypes.Contains(x.ModificationType, StringComparer.OrdinalIgnoreCase))
-                && (searchQuery.ReviewerId != null
-                    ? x.ReviewerId == searchQuery.ReviewerId
-                    : string.IsNullOrEmpty(x.ReviewerId) ));
+                && (!searchQuery.IncludeReviewerId
+                    || x.ReviewerId == searchQuery.ReviewerId));
     }
 
     private static IEnumerable<ProjectModificationResult> SortModifications(IEnumerable<ProjectModificationResult> modifications, string sortField, string sortDirection)


### PR DESCRIPTION
## What was the purpose of this ticket?

Provide a brief description of the ticket

## Jira Ref

Replace the `###` with the Jira Ticket number below

[RSP-###](https://nihr.atlassian.net/browse/RSP-###)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [] Refactoring
- [X] Bug-fix
- [] DevOps
- [] Testing

## Solution

What work was completed to cover off the story?

- List out changes made to the repo

## Checklist

- [ ] Your code builds clean without any  warnings
- [ ] You have added unit tests
- [ ] All the added unit tests add value i.e. assert the right thing?
- [ ] You are using the correct naming conventions
- [ ] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [ ] There are no dead code and no "TODO" comments left
- [ ] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.